### PR TITLE
Solution

### DIFF
--- a/.infrastructure/alpine.yml
+++ b/.infrastructure/alpine.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: alpine
+  namespace: todoapp
+spec:
+  containers:
+    - name: alpine
+      image: alpine
+      args:
+        - sleep
+        - "1000"

--- a/.infrastructure/namespace.yml
+++ b/.infrastructure/namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: todoapp

--- a/.infrastructure/todoapp-pod.yml
+++ b/.infrastructure/todoapp-pod.yml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: todoapp
+  namespace: todoapp
+  labels:
+    app: todoapp
+spec:
+  containers:
+    - name: todoapp
+      image: shu418/todoapp:3.0.0
+      ports:
+        - containerPort: 8080
+      livenessProbe:
+        httpGet:
+          path: api/health
+          port: 8080
+        initialDelaySeconds: 60
+        periodSeconds: 5
+      readinessProbe:
+        httpGet:
+          path: api/readiness
+          port: 8080
+        initialDelaySeconds: 60
+        periodSeconds: 5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+ARG PYTHON_VERSION=3.8
+FROM python:${PYTHON_VERSION} as builder
+
+WORKDIR /src
+COPY src .
+
+FROM python:${PYTHON_VERSION} as run
+
+WORKDIR /src
+
+ENV PYTHONUNBUFFERED=1
+
+COPY --from=builder /src .
+
+RUN pip install --upgrade pip && \
+    pip install -r requirements.txt
+
+EXPOSE 8080
+
+ENTRYPOINT ["sh", "-c", "python manage.py migrate && python manage.py runserver 0.0.0.0:8080"]

--- a/README.md
+++ b/README.md
@@ -1,55 +1,41 @@
-# Django ToDo list
+## To apply all manifests
 
-This is a todo list web application with basic features of most web apps, i.e., accounts/login, API, and interactive UI. To do this task, you will need:
-
-- CSS | [Skeleton](http://getskeleton.com/)
-- JS  | [jQuery](https://jquery.com/)
-
-## Explore
-
-Try it out by installing the requirements (the following commands work only with Python 3.8 and higher, due to Django 4):
-
+Use commands:
 ```
-pip install -r requirements.txt
+kubectl apply -f .infrastructure/namespace.yml
+```
+```
+kubectl apply -f .infrastructure/todoapp-pod.yml
+```
+```
+kubectl apply -f .infrastructure/alpine.yml
 ```
 
-Create a database schema:
+## To test application using the port-forward command
 
+Use this command:
 ```
-python manage.py migrate
-```
-
-And then start the server (default is http://localhost:8000):
-
-```
-python manage.py runserver
+kubectl port-forward pod/todoapp 8080:8080 -n todoapp
 ```
 
-Now you can browse the [API](http://localhost:8000/api/) or start on the [landing page](http://localhost:8000/).
+You can access the ToDo app in your browser at [http://localhost:8080](http://localhost:8080)
 
-## Task
+## To test application using 'Alpine' container
 
-Create a kubernetes manifest for a pod which will containa ToDo app container:
-
-1. Fork this repository.
-1. Create a simple `Dockerfile` for the ToDo application
-7. Add readiness endpoint code to `api` of the appliation (modify `api/views.py` and `api/urls.py`)
-1. Add liveness endpoint cide to `api` of the application (modify `api/views.py` and `api/urls.py`)
-1. Build your image and push to your personal Docker Hub account into the `todoapp` repository with the `3.0.0` tag (`todoapp:3.0.0`)
-1. All manifests should be located under `.infrastructure` folder
-1. Create a `manifest` which can be used to create a namespace. File should be named `namespace.yml` and should contain the following content:
+1. Get ip address of 'todoapp' pod:
 ```
-apiVersion: v1
-kind: Namespace
-metadata:
- name: todoapp
+kubectl get pods -n todoapp -o wide
 ```
-8. Creata a pod `manifest` which will start a `busyboxplus:curl` container in a cluster. File should be named `busybox.yml`.
-1. Create a pod `manifest` which will be using previously created image with tag `{yourname}/todoapp:3.0.0`. File should be named `todoapp-pod.yml`.
-1. ToDo app pod `manifest` should have a readiness probe configured
-1. ToDo app pod `manifest` should have a liveness probe configured
-1. `README.md` file should contain instructions on how to apply all manifests
-1. `README.md` file should contain instructions on how to test ToDo application using the `port-forward` command
-1. `README.md` file should contain instructions on how to test application using the
-`busyboxplus:curl` container
-1. Create PR with your changes and attach it for validation on a platform.
+2. Add the 'curl' package to the 'Alpine'
+```
+kubectl exec -it alpine -n todoapp -- apk --update add curl
+```
+3. Connect to 'Alpine'
+```
+kubectl exec -it alpine -n todoapp -- sh
+```
+4. Use commands:
+```
+curl http://{todoapp ip}:8080/api/liveness/
+curl http://{todoapp ip}:8080/api/readiness/
+```

--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -10,5 +10,7 @@ router.register(r"todos", views.TodoViewSet)
 
 app_name = "api"
 urlpatterns = [
-    path("", include(router.urls))
+    path("", include(router.urls)),
+    path("readiness/", views.readiness_check, name="readiness"),
+    path("liveness/", views.liveness_check, name="liveness")
 ]

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -5,8 +5,12 @@ from api.serializers import TodoListSerializer, TodoSerializer, UserSerializer
 from lists.models import Todo, TodoList
 
 from django.http import HttpResponse
-from django.utils import timezone
 import time
+
+
+start_time = time.time()
+start_period = 40
+
 
 class IsCreatorOrReadOnly(permissions.BasePermission):
     """
@@ -56,3 +60,14 @@ class TodoViewSet(viewsets.ModelViewSet):
         user = self.request.user
         creator = user if user.is_authenticated else None
         serializer.save(creator=creator)
+
+
+def readiness_check(request):
+    if time.time() < start_time + start_period:
+        return HttpResponse("Not Ready", status=503)
+    else:
+        return HttpResponse("Ready", status=200)
+
+
+def liveness_check(request):
+    return HttpResponse("Alive", status=200)


### PR DESCRIPTION
Couldn't resolve it:
```
Events:
  Type     Reason     Age                    From               Message
  ----     ------     ----                   ----               -------
  Normal   Scheduled  3m50s                  default-scheduler  Successfully assigned todoapp/busybox to docker-desktop
  Normal   Pulling    2m10s (x4 over 3m49s)  kubelet            Pulling image "radial/busyboxplus:curl"
  Warning  Failed     2m8s (x4 over 3m47s)   kubelet            Failed to pull image "radial/busyboxplus:curl": [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/radial/busyboxplus:curl to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
  Warning  Failed     2m8s (x4 over 3m47s)   kubelet            Error: ErrImagePull
  Warning  Failed     113s (x6 over 3m46s)   kubelet            Error: ImagePullBackOff
  Normal   BackOff    100s (x7 over 3m46s)   kubelet            Back-off pulling image "radial/busyboxplus:curl"
```
Used Alpine instead.